### PR TITLE
feat: Oauth 로그인 + 회원인증 기능 추가

### DIFF
--- a/src/main/java/com/codeit/blob/global/domain/ErrorResponse.java
+++ b/src/main/java/com/codeit/blob/global/domain/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.codeit.blob.global.domain;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+    private final int status;
+    private final String message;
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/exception/JwtExceptionHandler.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/JwtExceptionHandler.java
@@ -1,0 +1,85 @@
+package com.codeit.blob.jwt.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT Exception Handler
+ */
+@Slf4j
+public class JwtExceptionHandler extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JwtExpiredException e) {
+            jwtExpiredExceptionHandler(response);
+        } catch (IllegalArgumentException e) {
+            illegalArgumentExceptionHandler(response);
+        } catch (JwtValidationException e) {
+            jwtValidationExceptionHandler(response);
+        } catch (UserNotValidationException e) {
+            userNotValidationExceptionExceptionHandler(response);
+        }
+    }
+
+    //Jwt 만료 처리
+    private void jwtExpiredExceptionHandler(HttpServletResponse response) {
+        log.error("---[Expired Jwt Token]---");
+        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.JWT_EXPIRED);
+        setResponse(response, errorResponse);
+    }
+
+    //Jwt 유효성 검사 실패 처리
+    private void jwtValidationExceptionHandler(HttpServletResponse response) {
+        log.error("---[Jwt Validation Fail]---");
+        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.JWT_VALIDATED_FAIL);
+        setResponse(response, errorResponse);
+    }
+
+    //인증하지 않은 회원 실패 처리
+    private void userNotValidationExceptionExceptionHandler(HttpServletResponse response) {
+        log.error("---[User Must Need Validation]---");
+        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.USER_NOT_VALIDATED);
+        setResponse(response, errorResponse);
+    }
+
+    //미처리 에러
+    private void illegalArgumentExceptionHandler(HttpServletResponse response) {
+        log.error("---[Illegal Argument Exception]---");
+        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.ILLEGAL_ARGUMENT_ERROR);
+        setResponse(response, errorResponse);
+    }
+
+    private static void setResponse(HttpServletResponse response, ErrorResponse errorResponse) {
+        response.setStatus(errorResponse.getStatus());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        try {
+            String json = new ObjectMapper().writeValueAsString(errorResponse);
+            response.getWriter().write(json);
+        } catch (Exception e) {
+            log.error("---[Object Mapper Error : {}]---", e.getStackTrace(), e);
+        }
+    }
+
+    @Getter
+    private static class ErrorResponse {
+        private final int status;
+        private final String message;
+
+        public ErrorResponse(JwtStatus jwtStatus) {
+            this.status = jwtStatus.getStatus();
+            this.message = jwtStatus.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/exception/JwtExceptionHandler.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/JwtExceptionHandler.java
@@ -1,11 +1,11 @@
 package com.codeit.blob.jwt.exception;
 
+import com.codeit.blob.global.domain.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -34,28 +34,32 @@ public class JwtExceptionHandler extends OncePerRequestFilter {
     //Jwt 만료 처리
     private void jwtExpiredExceptionHandler(HttpServletResponse response) {
         log.error("---[Expired Jwt Token]---");
-        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.JWT_EXPIRED);
+        JwtStatus status = JwtStatus.JWT_EXPIRED;
+        ErrorResponse errorResponse = new ErrorResponse(status.getStatus(), status.getMessage());
         setResponse(response, errorResponse);
     }
 
     //Jwt 유효성 검사 실패 처리
     private void jwtValidationExceptionHandler(HttpServletResponse response) {
         log.error("---[Jwt Validation Fail]---");
-        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.JWT_VALIDATED_FAIL);
+        JwtStatus status = JwtStatus.JWT_VALIDATED_FAIL;
+        ErrorResponse errorResponse = new ErrorResponse(status.getStatus(), status.getMessage());
         setResponse(response, errorResponse);
     }
 
     //인증하지 않은 회원 실패 처리
     private void userNotValidationExceptionExceptionHandler(HttpServletResponse response) {
         log.error("---[User Must Need Validation]---");
-        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.USER_NOT_VALIDATED);
+        JwtStatus status = JwtStatus.USER_NOT_VALIDATED;
+        ErrorResponse errorResponse = new ErrorResponse(status.getStatus(), status.getMessage());
         setResponse(response, errorResponse);
     }
 
     //미처리 에러
     private void illegalArgumentExceptionHandler(HttpServletResponse response) {
         log.error("---[Illegal Argument Exception]---");
-        ErrorResponse errorResponse = new ErrorResponse(JwtStatus.ILLEGAL_ARGUMENT_ERROR);
+        JwtStatus status = JwtStatus.ILLEGAL_ARGUMENT_ERROR;
+        ErrorResponse errorResponse = new ErrorResponse(status.getStatus(), status.getMessage());
         setResponse(response, errorResponse);
     }
 
@@ -69,17 +73,6 @@ public class JwtExceptionHandler extends OncePerRequestFilter {
             response.getWriter().write(json);
         } catch (Exception e) {
             log.error("---[Object Mapper Error : {}]---", e.getStackTrace(), e);
-        }
-    }
-
-    @Getter
-    private static class ErrorResponse {
-        private final int status;
-        private final String message;
-
-        public ErrorResponse(JwtStatus jwtStatus) {
-            this.status = jwtStatus.getStatus();
-            this.message = jwtStatus.getMessage();
         }
     }
 }

--- a/src/main/java/com/codeit/blob/jwt/exception/JwtExpiredException.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/JwtExpiredException.java
@@ -1,0 +1,14 @@
+package com.codeit.blob.jwt.exception;
+
+import com.codeit.blob.jwt.exception.JwtStatus;
+import lombok.Getter;
+
+@Getter
+
+public class JwtExpiredException extends RuntimeException {
+    private final JwtStatus status;
+
+    public JwtExpiredException() {
+        this.status = JwtStatus.JWT_EXPIRED;
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/exception/JwtStatus.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/JwtStatus.java
@@ -1,0 +1,19 @@
+package com.codeit.blob.jwt.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtStatus {
+    ILLEGAL_ARGUMENT_ERROR(400, "존재하지 않는 회원입니다."),
+    JWT_EXPIRED(401, "Jwt 토큰이 만료되었습니다,"),
+    JWT_VALIDATED_FAIL(402, "유효하지 않은 토큰입니다."),
+    USER_NOT_VALIDATED(405, "인증되지 않은 회원입니다.");
+
+    private final int status;
+    private final String message;
+
+    JwtStatus(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/exception/JwtValidationException.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/JwtValidationException.java
@@ -1,0 +1,12 @@
+package com.codeit.blob.jwt.exception;
+
+import lombok.Getter;
+
+@Getter
+public class JwtValidationException extends RuntimeException {
+    private final JwtStatus status;
+
+    public JwtValidationException() {
+        this.status = JwtStatus.JWT_VALIDATED_FAIL;
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/exception/UserNotValidationException.java
+++ b/src/main/java/com/codeit/blob/jwt/exception/UserNotValidationException.java
@@ -1,0 +1,9 @@
+package com.codeit.blob.jwt.exception;
+
+public class UserNotValidationException extends RuntimeException {
+    private final JwtStatus status;
+
+    public UserNotValidationException() {
+        this.status = JwtStatus.JWT_EXPIRED;
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/blob/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,90 @@
+package com.codeit.blob.jwt.filter;
+
+import com.codeit.blob.jwt.exception.JwtExpiredException;
+import com.codeit.blob.jwt.exception.UserNotValidationException;
+import com.codeit.blob.oauth.domain.CustomUsers;
+import com.codeit.blob.jwt.provider.JwtProvider;
+import com.codeit.blob.jwt.exception.JwtValidationException;
+import com.codeit.blob.user.domain.Users;
+import com.codeit.blob.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String[] EXCLUDE_PATH = {
+            "/oauth", "/user", "/h2-console", "/swagger-ui", "/v3"
+    };
+
+    private final JwtProvider provider;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("--[Request URL : {}]", request.getRequestURL());
+
+        final String jwtPrefix = JwtProvider.JWT_PREFIX;
+        final String jwtToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("--[Request Jwt Token : {}]", jwtToken);
+
+        //access token validate
+        if (jwtToken == null || !jwtToken.startsWith(jwtPrefix)) {
+            log.info("---[Access Token Not Validation]---");
+            throw new JwtValidationException();
+        }
+
+        try {
+            String accessToken = jwtToken.substring(jwtPrefix.length() - 1);
+            if (!provider.isTokenExpired(accessToken)) {
+                log.info("---[Access Token Not Expired]---");
+
+                String oauthId = provider.extractClaim(accessToken, claims -> String.valueOf(claims.get("oauthId")));
+                Users users = userRepository.findByOauthId(oauthId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+
+                if (users.getBlobId() == null || users.getNickName() == null) {
+                    throw new UserNotValidationException();
+                }
+
+                CustomUsers userDetail = new CustomUsers(users);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetail, userDetail.getPassword(), userDetail.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.info("---[Jwt Validate Success]---");
+            }
+
+        } catch (ExpiredJwtException e) {
+            log.error("---[Access Token Expired]---");
+            throw new JwtExpiredException();
+        } catch (SignatureException e) {
+            log.info("---[Access Token Not Validation]---");
+            throw new JwtValidationException();
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return Arrays.stream(EXCLUDE_PATH)
+                .anyMatch(path::startsWith);
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/provider/CookieProvider.java
+++ b/src/main/java/com/codeit/blob/jwt/provider/CookieProvider.java
@@ -1,0 +1,17 @@
+package com.codeit.blob.jwt.provider;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CookieProvider {
+    public ResponseCookie createCookie(String cookieName, String data) {
+        return ResponseCookie.from(cookieName, data)
+                .path("/")
+                .httpOnly(true)
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/codeit/blob/jwt/provider/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.codeit.blob.jwt.provider;
+
+import com.codeit.blob.user.domain.Users;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+public class JwtProvider {
+    public static final String JWT_PREFIX = "Bearer ";
+    private static final String SECRET_KEY = "asdfadfasfasfsadfasfasdfasdfasfasdfsdfasdfasdfasfasdfafasfasdfasd";
+    private static final long ACCESS_EXPIRE_DATE = 1000L * 30;
+    private static final long REFRESH_EXPIRE_DATE = 1000L * 60;
+
+    public String generateAccessToken(Map<String, Object> extractClaims) {
+        return Jwts.builder()
+                .setClaims(extractClaims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_EXPIRE_DATE))
+                .signWith(getSignKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Map<String, Object> extractClaims) {
+        return Jwts.builder()
+                .setClaims(extractClaims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_EXPIRE_DATE))
+                .signWith(getSignKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = extractAllClaims(token);
+        return claimsResolver.apply(claims);
+    }
+
+    private Claims extractAllClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSignKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public boolean isTokenValid(String token, Users user) {
+        final String oauthId = extractClaim(token, claims -> claims.get("oauthId", String.class));
+        return (oauthId.equals(user.getOauthId())) && !isTokenExpired(token);
+    }
+
+    public boolean isTokenExpired(String token) {
+        return extractClaim(token, Claims::getExpiration)
+                .before(new Date());
+    }
+
+
+    private Key getSignKey() {
+        byte[] decode = Decoders.BASE64.decode(SECRET_KEY);
+        return Keys.hmacShaKeyFor(decode);
+    }
+}

--- a/src/main/java/com/codeit/blob/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/codeit/blob/jwt/provider/JwtProvider.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
@@ -16,9 +17,11 @@ import java.util.function.Function;
 @Component
 public class JwtProvider {
     public static final String JWT_PREFIX = "Bearer ";
-    private static final String SECRET_KEY = "asdfadfasfasfsadfasfasdfasdfasfasdfsdfasdfasdfasfasdfafasfasdfasd";
-    private static final long ACCESS_EXPIRE_DATE = 1000L * 30;
-    private static final long REFRESH_EXPIRE_DATE = 1000L * 60;
+
+    @Value("${oauth2.jwt.secret-key}")
+    private String secretKey;
+    private static final long ACCESS_EXPIRE_DATE = 1000L * 60 * 60;
+    private static final long REFRESH_EXPIRE_DATE = 1000L * 60 * 60 * 2;
 
     public String generateAccessToken(Map<String, Object> extractClaims) {
         return Jwts.builder()
@@ -63,7 +66,7 @@ public class JwtProvider {
 
 
     private Key getSignKey() {
-        byte[] decode = Decoders.BASE64.decode(SECRET_KEY);
+        byte[] decode = Decoders.BASE64.decode(secretKey);
         return Keys.hmacShaKeyFor(decode);
     }
 }

--- a/src/main/java/com/codeit/blob/oauth/OauthType.java
+++ b/src/main/java/com/codeit/blob/oauth/OauthType.java
@@ -1,7 +1,16 @@
 package com.codeit.blob.oauth;
 
+import java.util.Arrays;
+
 public enum OauthType {
     GOOGLE,
     KAKAO,
     NAVER;
+
+    public static OauthType toOauthType(String oauthType) {
+        return Arrays.stream(OauthType.values())
+                .filter(type -> type.name().equals(oauthType.toUpperCase()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 Oauth Type 입니다. {}" + oauthType));
+    }
 }

--- a/src/main/java/com/codeit/blob/oauth/controller/OauthController.java
+++ b/src/main/java/com/codeit/blob/oauth/controller/OauthController.java
@@ -58,6 +58,7 @@ public class OauthController {
     public ResponseEntity<Object> refresh(
             HttpServletRequest request
     ) {
+        //TODO KDY 리팩토링 필요
         String refreshToken = request.getHeader(HttpHeaders.AUTHORIZATION);
         if (!jwtProvider.isTokenExpired(refreshToken)) {
             Users users = userRepository.findByRefreshToken(refreshToken)

--- a/src/main/java/com/codeit/blob/oauth/dto/google/GoogleDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/google/GoogleDto.java
@@ -3,6 +3,7 @@ package com.codeit.blob.oauth.dto.google;
 import lombok.Getter;
 
 @Getter
+// TODO KDY Json Property 설정 필요
 public class GoogleDto {
     private final String access_token;
     private final String expires_in;

--- a/src/main/java/com/codeit/blob/oauth/dto/google/GoogleUserDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/google/GoogleUserDto.java
@@ -3,6 +3,7 @@ package com.codeit.blob.oauth.dto.google;
 import lombok.Getter;
 
 @Getter
+// TODO KDY Json Property 설정 필요
 public class GoogleUserDto {
     private final String id;
     private final String email;

--- a/src/main/java/com/codeit/blob/oauth/dto/kakao/KakaoDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/kakao/KakaoDto.java
@@ -3,6 +3,7 @@ package com.codeit.blob.oauth.dto.kakao;
 import lombok.Getter;
 
 @Getter
+// TODO KDY Json Property 설정 필요
 public class KakaoDto {
     private final String access_token;
     private final String token_type;

--- a/src/main/java/com/codeit/blob/oauth/dto/kakao/KakaoUserDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/kakao/KakaoUserDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 
 @Getter
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+// TODO KDY Json Property 설정 필요
 public class KakaoUserDto {
     private String id;
     private KakaoAccount kakaoAccount;

--- a/src/main/java/com/codeit/blob/oauth/dto/naver/NaverDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/naver/NaverDto.java
@@ -3,6 +3,7 @@ package com.codeit.blob.oauth.dto.naver;
 import lombok.Getter;
 
 @Getter
+// TODO KDY Json Property 설정 필요
 public class NaverDto {
     private final String access_token;
     private final String refresh_token;

--- a/src/main/java/com/codeit/blob/oauth/dto/naver/NaverUserDto.java
+++ b/src/main/java/com/codeit/blob/oauth/dto/naver/NaverUserDto.java
@@ -3,6 +3,7 @@ package com.codeit.blob.oauth.dto.naver;
 import lombok.Getter;
 
 @Getter
+// TODO KDY Json Property 설정 필요
 public class NaverUserDto {
     private final String resultcode;
     private final String message;

--- a/src/main/java/com/codeit/blob/oauth/exception/OauthExceptionHandler.java
+++ b/src/main/java/com/codeit/blob/oauth/exception/OauthExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.codeit.blob.oauth.exception;
+
+import com.codeit.blob.jwt.exception.JwtExpiredException;
+import com.codeit.blob.jwt.exception.JwtStatus;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.security.SignatureException;
+
+@RestControllerAdvice
+public class OauthExceptionHandler {
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ErrorResponse> expiredJwtExceptionHandler(ExpiredJwtException e) {
+        return ResponseEntity.status(402).body(new ErrorResponse(JwtStatus.JWT_EXPIRED));
+    }
+
+    @ExceptionHandler(SignatureException.class)
+    public ResponseEntity<ErrorResponse> signatureExceptionHandler(SignatureException e) {
+        return ResponseEntity.status(402).body(new ErrorResponse(JwtStatus.JWT_VALIDATED_FAIL));
+    }
+
+    @Getter
+    public static class ErrorResponse {
+        private final int status;
+        private final String message;
+
+        public ErrorResponse(JwtStatus status) {
+            this.status = status.getStatus();
+            this.message = status.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/codeit/blob/oauth/exception/OauthExceptionHandler.java
+++ b/src/main/java/com/codeit/blob/oauth/exception/OauthExceptionHandler.java
@@ -1,12 +1,10 @@
 package com.codeit.blob.oauth.exception;
 
-import com.codeit.blob.jwt.exception.JwtExpiredException;
+import com.codeit.blob.global.domain.ErrorResponse;
 import com.codeit.blob.jwt.exception.JwtStatus;
 import io.jsonwebtoken.ExpiredJwtException;
-import lombok.Getter;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.security.SignatureException;
@@ -15,22 +13,13 @@ import java.security.SignatureException;
 public class OauthExceptionHandler {
     @ExceptionHandler(ExpiredJwtException.class)
     public ResponseEntity<ErrorResponse> expiredJwtExceptionHandler(ExpiredJwtException e) {
-        return ResponseEntity.status(402).body(new ErrorResponse(JwtStatus.JWT_EXPIRED));
+        JwtStatus status = JwtStatus.JWT_EXPIRED;
+        return ResponseEntity.status(402).body(new ErrorResponse(status.getStatus(), status.getMessage()));
     }
 
     @ExceptionHandler(SignatureException.class)
     public ResponseEntity<ErrorResponse> signatureExceptionHandler(SignatureException e) {
-        return ResponseEntity.status(402).body(new ErrorResponse(JwtStatus.JWT_VALIDATED_FAIL));
-    }
-
-    @Getter
-    public static class ErrorResponse {
-        private final int status;
-        private final String message;
-
-        public ErrorResponse(JwtStatus status) {
-            this.status = status.getStatus();
-            this.message = status.getMessage();
-        }
+        JwtStatus status = JwtStatus.JWT_VALIDATED_FAIL;
+        return ResponseEntity.status(402).body(new ErrorResponse(status.getStatus(), status.getMessage()));
     }
 }

--- a/src/main/java/com/codeit/blob/oauth/response/OauthResponse.java
+++ b/src/main/java/com/codeit/blob/oauth/response/OauthResponse.java
@@ -1,12 +1,18 @@
 package com.codeit.blob.oauth.response;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class OauthResponse {
     private final String oauthId;
+    private final String accessToken;
+    private final String refreshToken;
 
-    public OauthResponse(String oauthId) {
+    @Builder
+    public OauthResponse(String oauthId, String accessToken, String refreshToken) {
         this.oauthId = oauthId;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/codeit/blob/oauth/service/KakaoService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/KakaoService.java
@@ -1,13 +1,16 @@
 package com.codeit.blob.oauth.service;
 
-import com.codeit.blob.user.UserAuthenticateType;
-import com.codeit.blob.user.request.UserRequest;
+import com.codeit.blob.oauth.OauthType;
+import com.codeit.blob.jwt.provider.JwtProvider;
+import com.codeit.blob.oauth.provider.KakaoProperties;
+import com.codeit.blob.oauth.response.OauthResponse;
+import com.codeit.blob.user.UserAuthenticateState;
+import com.codeit.blob.user.domain.Users;
 import com.codeit.blob.oauth.dto.kakao.KakaoDto;
 import com.codeit.blob.oauth.dto.kakao.KakaoUserDto;
-import com.codeit.blob.oauth.provider.OauthProperties;
 import com.codeit.blob.user.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -16,13 +19,20 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
-public class KakaoService extends OauthService {
+@RequiredArgsConstructor
+public class KakaoService implements OauthService {
+
+    private final KakaoProperties properties;
+    private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
-    public KakaoService(@Qualifier("kakaoProperties") OauthProperties properties, UserRepository userRepository) {
-        super(properties);
-        this.userRepository = userRepository;
+    @Override
+    public OauthType getOauthType() {
+        return properties.getOauthType();
     }
 
     @Override
@@ -36,26 +46,34 @@ public class KakaoService extends OauthService {
     }
 
     @Override
-    public Object createToken(String code) {
+    public OauthResponse createToken(String code) {
         KakaoDto oauthToken = getOauthToken(code);
-        String accessToken = oauthToken.getAccess_token();
-        KakaoUserDto userInfo = getUserInfo(accessToken);
+        KakaoUserDto userInfo = getUserInfo(oauthToken.getAccess_token());
 
-        WebClient.create().post()
-                .uri("http://localhost:8080/account")
-                .bodyValue(
-                        UserRequest.builder()
+        Map<String, Object> extractClaims = new HashMap<>();
+        extractClaims.put("oauthId", userInfo.getId());
+
+        String accessToken = jwtProvider.generateAccessToken(extractClaims);
+        String refreshToken = jwtProvider.generateRefreshToken(extractClaims);
+
+        Users users = userRepository.findByOauthId(userInfo.getId())
+                .orElseGet(() ->
+                        Users.builder()
                                 .oauthId(userInfo.getId())
                                 .email(userInfo.getEmail())
                                 .profileUrl(userInfo.getProfile())
-                                .userAuthenticateType(UserAuthenticateType.BLOCKED)
+                                .state(UserAuthenticateState.BLOCKED)
                                 .oauthType(properties.getOauthType())
+                                .refreshToken(refreshToken)
                                 .build()
-                ).retrieve()
-                .bodyToMono(Void.class)
-                .subscribe();
+                );
+        userRepository.save(users);
 
-        return userInfo;
+        return OauthResponse.builder()
+                .oauthId(userInfo.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/codeit/blob/oauth/service/OauthManager.java
+++ b/src/main/java/com/codeit/blob/oauth/service/OauthManager.java
@@ -17,7 +17,7 @@ public class OauthManager {
     public OauthManager(Set<OauthService> services) {
         enumMap = new EnumMap<>(OauthType.class);
         Assert.notEmpty(services, "oauth provider must not empty");
-        services.forEach(service -> enumMap.put(service.oauthType, service));
+        services.forEach(service -> enumMap.put(service.getOauthType(), service));
     }
 
     public OauthService getService(@NonNull OauthType oauthType) {

--- a/src/main/java/com/codeit/blob/oauth/service/OauthService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/OauthService.java
@@ -1,33 +1,17 @@
 package com.codeit.blob.oauth.service;
 
 import com.codeit.blob.oauth.OauthType;
-import com.codeit.blob.oauth.provider.OauthProperties;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.UriComponentsBuilder;
+import com.codeit.blob.oauth.response.OauthResponse;
 
-@Slf4j
-public abstract class OauthService {
-    protected final OauthProperties properties;
-    public final OauthType oauthType;
+public interface OauthService {
 
-    public OauthService(OauthProperties properties) {
-        this.properties = properties;
-        this.oauthType = properties.getOauthType();
-    }
+    OauthType getOauthType();
 
-    public String createLoginUrl() {
-        return UriComponentsBuilder.fromHttpUrl(properties.getAuthUrl())
-                .queryParam("client_id", properties.getClientId())
-                .queryParam("redirect_uri", properties.getRedirectUrl())
-                .queryParam("scope", properties.getScope())
-                .queryParam("response_type", "code")
-                .toUriString();
-    }
+    String createLoginUrl();
 
-    public abstract Object createToken(String code);
+    OauthResponse createToken(String code);
 
-    public abstract Object getOauthToken(String code);
+    Object getOauthToken(String code);
 
-    public abstract Object getUserInfo(String oauthToken);
+    Object getUserInfo(String oauthToken);
 }

--- a/src/main/java/com/codeit/blob/oauth/service/TokenService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/TokenService.java
@@ -1,0 +1,22 @@
+package com.codeit.blob.oauth.service;
+
+import com.codeit.blob.jwt.provider.JwtProvider;
+import com.codeit.blob.user.domain.Users;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtProvider jwtProvider;
+
+    public String createRefreshToken(Users users) {
+        Map<String, Object> extractClaims = new HashMap<>();
+        extractClaims.put("oauthId", users.getOauthId());
+
+        return jwtProvider.generateRefreshToken(extractClaims);
+    }
+}

--- a/src/main/java/com/codeit/blob/user/UserAuthenticateState.java
+++ b/src/main/java/com/codeit/blob/user/UserAuthenticateState.java
@@ -1,6 +1,6 @@
 package com.codeit.blob.user;
 
-public enum UserAuthenticateType {
+public enum UserAuthenticateState {
     NORMAL,
     BLOCKED,
     DELETED,

--- a/src/main/java/com/codeit/blob/user/controller/UserController.java
+++ b/src/main/java/com/codeit/blob/user/controller/UserController.java
@@ -1,23 +1,42 @@
 package com.codeit.blob.user.controller;
 
 import com.codeit.blob.user.request.UserRequest;
+import com.codeit.blob.user.response.UserResponse;
 import com.codeit.blob.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/account")
+@RequestMapping("/user")
+@Tag(name = "User API", description = "회원 CRUD API")
 public class UserController {
     private final UserService userService;
 
     @PostMapping
-    public void createAccount(
+    @Operation(summary = "회원 인증 API", description = "blobId, nickName 을 입력 받아 인증합니다.")
+    public ResponseEntity<UserResponse> validationUser(
             @RequestBody UserRequest userRequest
     ) {
-        userService.join(userRequest);
+        return ResponseEntity.ok(userService.validationUser(userRequest));
+    }
+
+    @GetMapping("/{blobId}/blob")
+    @Operation(summary = "회원 조회 API", description = "Blob Id 를 입력받아 회원을 조회합니다.")
+    public ResponseEntity<UserResponse> findUserByBlobId(
+            @PathVariable("blobId") String blobId
+    ) {
+        return ResponseEntity.ok(userService.findByBlobId(blobId));
+    }
+
+    @GetMapping("/{oauthId}/oauth")
+    @Operation(summary = "회원 조회 API", description = "Oauth Id 를 입력받아 회원을 조회합니다.")
+    public ResponseEntity<UserResponse> findUserByOauthId(
+            @PathVariable("oauthId") String oauthId
+    ) {
+        return ResponseEntity.ok(userService.findByOauthId(oauthId));
     }
 }

--- a/src/main/java/com/codeit/blob/user/domain/Users.java
+++ b/src/main/java/com/codeit/blob/user/domain/Users.java
@@ -1,6 +1,6 @@
 package com.codeit.blob.user.domain;
 
-import com.codeit.blob.user.UserAuthenticateType;
+import com.codeit.blob.user.UserAuthenticateState;
 import com.codeit.blob.global.domain.BaseTimeEntity;
 import com.codeit.blob.oauth.OauthType;
 import jakarta.persistence.*;
@@ -21,21 +21,35 @@ public class Users extends BaseTimeEntity {
     private String blobId;
     private String nickName;
     private String profileUrl;
+    private String refreshToken;
 
     @Enumerated(EnumType.STRING)
-    private UserAuthenticateType userAuthenticateType;
+    private UserAuthenticateState state;
 
     @Enumerated(EnumType.STRING)
     private OauthType oauthType;
 
-    @Builder
-    public Users(String email, String oauthId, String blobId, String nickName, String profileUrl, UserAuthenticateType userAuthenticateType, OauthType oauthType) {
+
+    @Builder(toBuilder = true)
+    public Users(String email, String oauthId, String blobId, String nickName, String profileUrl, String refreshToken, UserAuthenticateState state, OauthType oauthType) {
         this.email = email;
         this.oauthId = oauthId;
         this.blobId = blobId;
         this.nickName = nickName;
         this.profileUrl = profileUrl;
-        this.userAuthenticateType = userAuthenticateType;
+        this.refreshToken = refreshToken;
+        this.state = state;
         this.oauthType = oauthType;
+    }
+
+    public void changeUser(Users users) {
+        this.email = users.getEmail();
+        this.oauthId = users.getOauthId();
+        this.blobId = users.getBlobId();
+        this.nickName = users.getNickName();
+        this.profileUrl = users.getProfileUrl();
+        this.refreshToken = users.getRefreshToken();
+        this.state = users.getState();
+        this.oauthType = users.getOauthType();
     }
 }

--- a/src/main/java/com/codeit/blob/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/blob/user/repository/UserRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByOauthId(String oauthId);
+
+    Optional<Users> findByBlobId(String blobId);
+
+    Optional<Users> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/codeit/blob/user/request/UserRequest.java
+++ b/src/main/java/com/codeit/blob/user/request/UserRequest.java
@@ -1,28 +1,18 @@
 package com.codeit.blob.user.request;
 
-import com.codeit.blob.user.UserAuthenticateType;
-import com.codeit.blob.oauth.OauthType;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class UserRequest {
     private final String oauthId;
-    private final String email;
     private final String blobId;
     private final String nickName;
-    private final String profileUrl;
-    private final UserAuthenticateType userAuthenticateType;
-    private final OauthType oauthType;
 
     @Builder
-    public UserRequest(String oauthId, String email, String blobId, String nickName, String profileUrl, UserAuthenticateType userAuthenticateType, OauthType oauthType) {
+    public UserRequest(String oauthId, String blobId, String nickName) {
         this.oauthId = oauthId;
-        this.email = email;
         this.blobId = blobId;
         this.nickName = nickName;
-        this.profileUrl = profileUrl;
-        this.userAuthenticateType = userAuthenticateType;
-        this.oauthType = oauthType;
     }
 }

--- a/src/main/java/com/codeit/blob/user/request/UserUpdateRequest.java
+++ b/src/main/java/com/codeit/blob/user/request/UserUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.codeit.blob.user.request;
+
+import com.codeit.blob.user.UserAuthenticateState;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserUpdateRequest {
+    private final String oauthId;
+    private final String blobId;
+    private final String nickName;
+    private final UserAuthenticateState userAuthenticateState;
+
+    @Builder
+    public UserUpdateRequest(String oauthId, String blobId, String nickName, UserAuthenticateState userAuthenticateState) {
+        this.oauthId = oauthId;
+        this.blobId = blobId;
+        this.nickName = nickName;
+        this.userAuthenticateState = userAuthenticateState;
+    }
+}

--- a/src/main/java/com/codeit/blob/user/response/UserResponse.java
+++ b/src/main/java/com/codeit/blob/user/response/UserResponse.java
@@ -13,7 +13,6 @@ public class UserResponse {
     private final String profileUrl;
     private final UserAuthenticateState state;
 
-    @Builder
     public UserResponse(Users users) {
         this.email = users.getEmail();
         this.blobId = users.getBlobId();

--- a/src/main/java/com/codeit/blob/user/response/UserResponse.java
+++ b/src/main/java/com/codeit/blob/user/response/UserResponse.java
@@ -1,0 +1,24 @@
+package com.codeit.blob.user.response;
+
+import com.codeit.blob.user.UserAuthenticateState;
+import com.codeit.blob.user.domain.Users;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserResponse {
+    private final String email;
+    private final String blobId;
+    private final String nickName;
+    private final String profileUrl;
+    private final UserAuthenticateState state;
+
+    @Builder
+    public UserResponse(Users users) {
+        this.email = users.getEmail();
+        this.blobId = users.getBlobId();
+        this.nickName = users.getNickName();
+        this.profileUrl = users.getProfileUrl();
+        this.state = users.getState();
+    }
+}

--- a/src/main/java/com/codeit/blob/user/service/UserService.java
+++ b/src/main/java/com/codeit/blob/user/service/UserService.java
@@ -1,31 +1,64 @@
 package com.codeit.blob.user.service;
 
+import com.codeit.blob.user.UserAuthenticateState;
 import com.codeit.blob.user.domain.Users;
 import com.codeit.blob.user.repository.UserRepository;
 import com.codeit.blob.user.request.UserRequest;
+import com.codeit.blob.user.response.UserResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public Users join(UserRequest userRequest) {
+    public UserResponse validationUser(UserRequest userRequest) {
         Users users = userRepository.findByOauthId(userRequest.getOauthId())
-                .orElseGet(() -> Users.builder()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
+
+        users.changeUser(
+                users.toBuilder()
                         .oauthId(userRequest.getOauthId())
-                        .email(userRequest.getEmail())
                         .blobId(userRequest.getBlobId())
                         .nickName(userRequest.getNickName())
-                        .profileUrl(userRequest.getProfileUrl())
-                        .userAuthenticateType(userRequest.getUserAuthenticateType())
-                        .oauthType(userRequest.getOauthType())
-                        .build());
+                        .state(UserAuthenticateState.NORMAL)
+                        .build()
+        );
+        userRepository.save(users);
 
-        Users save = userRepository.save(users);
-        return save;
+        return UserResponse.builder()
+                .users(users)
+                .build();
+    }
+
+    public UserResponse findByOauthId(String oauthId) {
+        Users users = userRepository.findByOauthId(oauthId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
+
+        return UserResponse.builder()
+                .users(users)
+                .build();
+    }
+
+    public UserResponse findByBlobId(String blobId) {
+        Users users = userRepository.findByBlobId(blobId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
+
+        return UserResponse.builder()
+                .users(users)
+                .build();
+    }
+
+    public UserResponse findByRefreshToken(String refreshToken) {
+        Users users = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
+
+        return UserResponse.builder()
+                .users(users)
+                .build();
     }
 }

--- a/src/main/java/com/codeit/blob/user/service/UserService.java
+++ b/src/main/java/com/codeit/blob/user/service/UserService.java
@@ -30,35 +30,27 @@ public class UserService {
         );
         userRepository.save(users);
 
-        return UserResponse.builder()
-                .users(users)
-                .build();
+        return new UserResponse(users);
     }
 
     public UserResponse findByOauthId(String oauthId) {
         Users users = userRepository.findByOauthId(oauthId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
 
-        return UserResponse.builder()
-                .users(users)
-                .build();
+        return new UserResponse(users);
     }
 
     public UserResponse findByBlobId(String blobId) {
         Users users = userRepository.findByBlobId(blobId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
 
-        return UserResponse.builder()
-                .users(users)
-                .build();
+        return new UserResponse(users);
     }
 
     public UserResponse findByRefreshToken(String refreshToken) {
         Users users = userRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원 아이디 입니다."));
 
-        return UserResponse.builder()
-                .users(users)
-                .build();
+        return new UserResponse(users);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -40,3 +40,5 @@ oauth2:
     client-id: ${OAUTH2_NAVER_CLIENT_ID}
     secret-key: ${OAUTH2_NAVER_SECRET_KEY}
     redirect-url: ${OAUTH2_NAVER_REDIRECT_URL}
+  jwt:
+    secret-key: ${OAUTH2_JWT_SECRET_KEY}


### PR DESCRIPTION
## 설명
* 로컬 개발 환경에만 적용
* google, kakao, naver 로그인 추가
* access, refresh 은 현재 body 로 전달. ( 둘다 Bearer 제외 )
* 프론트에서는 access, refresh 토큰을 header 로 전송
* access 만료시 refresh 을 header 로 전송 ( refresh 만 Bearer 제외 )
* Oauth 로그인 이후 추가적인 인증 필요, 인증 미완료시 로그인 불가 ( 405, 미인증 에러 발생 )
* access, refresh 둘다 만료시 다시 로그인
* 현재는 매우 짧은 시간으로 설정함 30초, 60초
* 레디스는.... 나중에

## 에러 코드
* 400 에러 - 존재하지 않는 회원
* 401 에러 - JWT 토큰 만료 ( access, refresh 동일 )
* 402 에러 - JWT 토큰 유효성 검사 실패
* 405 에러 - 인증하지 않은 USER 로그인 ( blobId, nickName )

## 처음 로그인
<img width="758" alt="image" src="https://github.com/PROJECT-BLOB/back-end/assets/26371135/b0a03649-a34d-4ae8-abb0-094c385cf250">

## access token 재발급 요청
<img width="761" alt="image" src="https://github.com/PROJECT-BLOB/back-end/assets/26371135/508d1e43-f1fd-41a7-b0f2-d7279932f87d">
