### PR TITLE
Feat/comment updates

### DIFF
--- a/src/main/java/com/codeit/blob/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/blob/comment/controller/CommentController.java
@@ -67,6 +67,17 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getPostComments(userDetails, postId, page, limit));
     }
 
+    @GetMapping("/reply/{commentId}")
+    @Operation(summary = "답글 조회 API", description = "commentId를 받아 해당 댓글의 답글을 오래된순으로 조회합니다. (토큰 필수 X)")
+    public ResponseEntity<CommentPageResponse> getCommentReplies(
+            @AuthenticationPrincipal CustomUsers userDetails,
+            @PathVariable Long commentId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(commentService.getCommentReplies(userDetails, commentId, page, limit));
+    }
+
     @PostMapping("/like/{commentId}")
     @Operation(summary = "댓글 좋아요/취소 API", description = "commentId를 받아 댓글에 좋아요를 추가하거나 이미 좋아요를 누른 경우 취소합니다.")
     public ResponseEntity<CommentResponse> likeComment(

--- a/src/main/java/com/codeit/blob/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/blob/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.codeit.blob.comment.controller;
 
 import com.codeit.blob.comment.request.CreateCommentRequest;
+import com.codeit.blob.comment.response.CommentPageResponse;
 import com.codeit.blob.comment.response.CommentResponse;
 import com.codeit.blob.comment.response.DeleteCommentResponse;
 import com.codeit.blob.comment.service.CommentService;
@@ -57,12 +58,13 @@ public class CommentController {
 
     @GetMapping("/post/{postId}")
     @Operation(summary = "댓글 조회 API", description = "postId를 받아 해당 게시글의 댓글을 오래된순으로 조회합니다. (토큰 필수 X)")
-    public ResponseEntity<List<CommentResponse>> getPostComments(
+    public ResponseEntity<CommentPageResponse> getPostComments(
             @AuthenticationPrincipal CustomUsers userDetails,
             @PathVariable Long postId,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int limit
     ) {
-        return ResponseEntity.ok(commentService.getPostComments(userDetails, postId, page));
+        return ResponseEntity.ok(commentService.getPostComments(userDetails, postId, page, limit));
     }
 
     @PostMapping("/like/{commentId}")

--- a/src/main/java/com/codeit/blob/comment/domain/Comment.java
+++ b/src/main/java/com/codeit/blob/comment/domain/Comment.java
@@ -22,6 +22,7 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/codeit/blob/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/codeit/blob/comment/repository/CommentJpaRepository.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
-    Page<Comment> findByPostOrderByCreatedDateAsc(Post post, Pageable pageable);
+    Page<Comment> findByPostAndParentOrderByCreatedDateAsc(Post post, Comment parent, Pageable pageable);
+
+    Page<Comment> findByParentIdOrderByCreatedDateAsc(Long parentId, Pageable pageable);
 
 }

--- a/src/main/java/com/codeit/blob/comment/request/CreateCommentRequest.java
+++ b/src/main/java/com/codeit/blob/comment/request/CreateCommentRequest.java
@@ -2,6 +2,7 @@ package com.codeit.blob.comment.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,8 @@ import lombok.NoArgsConstructor;
 public class CreateCommentRequest {
 
     @NotEmpty(message = "댓글 내용은 필수값입니다.")
-    @Schema(description = "댓글 내용", example = "content")
+    @Size(max = 1000)
+    @Schema(description = "댓글 내용, 최대 1000자", example = "content")
     private String content;
 
 }

--- a/src/main/java/com/codeit/blob/comment/response/CommentPageResponse.java
+++ b/src/main/java/com/codeit/blob/comment/response/CommentPageResponse.java
@@ -1,0 +1,24 @@
+package com.codeit.blob.comment.response;
+
+import com.codeit.blob.comment.domain.Comment;
+import com.codeit.blob.user.domain.Users;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(name = "댓글 페이지 응답")
+public class CommentPageResponse {
+
+    private final List<CommentResponse> content;
+    private final long count;
+    private final int currentPage;
+    private final boolean hasMore;
+
+    public CommentPageResponse(Page<Comment> page, Users user){
+        this.content = page.getContent().stream().map(c -> new CommentResponse(c, user)).toList();
+        this.count = page.getTotalElements();
+        this.currentPage = page.getNumber();
+        this.hasMore = page.hasNext();
+    }
+}

--- a/src/main/java/com/codeit/blob/comment/response/CommentPageResponse.java
+++ b/src/main/java/com/codeit/blob/comment/response/CommentPageResponse.java
@@ -3,22 +3,26 @@ package com.codeit.blob.comment.response;
 import com.codeit.blob.comment.domain.Comment;
 import com.codeit.blob.user.domain.Users;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
+@Getter
 @Schema(name = "댓글 페이지 응답")
 public class CommentPageResponse {
 
     private final List<CommentResponse> content;
     private final long count;
-    private final int currentPage;
+    private final long currentPage;
     private final boolean hasMore;
+    private final long remaining;
 
     public CommentPageResponse(Page<Comment> page, Users user){
         this.content = page.getContent().stream().map(c -> new CommentResponse(c, user)).toList();
         this.count = page.getTotalElements();
         this.currentPage = page.getNumber();
         this.hasMore = page.hasNext();
+        this.remaining = Math.max(0, page.getTotalElements() - (page.getNumber() + 1L) * page.getSize());
     }
 }

--- a/src/main/java/com/codeit/blob/comment/response/CommentResponse.java
+++ b/src/main/java/com/codeit/blob/comment/response/CommentResponse.java
@@ -12,7 +12,8 @@ import java.util.List;
 @Getter
 @Schema(name = "댓글 정보 응답")
 public class CommentResponse {
-    private final Long id;
+    private final Long commentId;
+    private final Long postId;
     private final String content;
     private final UserProfileResponse author;
     @Schema(example = "2024-04-24T12:59:24")
@@ -20,16 +21,15 @@ public class CommentResponse {
     private final boolean liked;
     private final int likeCount;
     private final boolean canDelete;
-    private final List<CommentResponse> reply;
 
     public CommentResponse(Comment comment, Users user){
-        this.id = comment.getId();
+        this.commentId = comment.getId();
+        this.postId = comment.getPost().getId();
         this.content = comment.getContent();
         this.author = new UserProfileResponse(comment.getAuthor());
         this.createdDate = comment.getCreatedDate().truncatedTo(ChronoUnit.SECONDS).toString();
         this.liked = user != null && comment.getLikes().stream().map(l -> l.getUser().getId()).toList().contains(user.getId());
         this.likeCount = comment.getLikes().size();
         this.canDelete = user != null && comment.getAuthor().getId().equals(user.getId());
-        this.reply = comment.getReply().stream().map(r -> new CommentResponse(r, user)).toList();
     }
 }

--- a/src/main/java/com/codeit/blob/comment/response/DeleteCommentResponse.java
+++ b/src/main/java/com/codeit/blob/comment/response/DeleteCommentResponse.java
@@ -8,11 +8,13 @@ import lombok.Getter;
 public class DeleteCommentResponse {
 
     private final Long commentId;
+    private final Long postId;
     @Schema(example = "댓글 삭제 성공")
     private final String message;
 
-    public DeleteCommentResponse(Long commentId){
+    public DeleteCommentResponse(Long commentId, Long postId){
         this.commentId = commentId;
+        this.postId = postId;
         this.message = "댓글 삭제 성공";
     }
 

--- a/src/main/java/com/codeit/blob/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/blob/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import com.codeit.blob.comment.domain.CommentLike;
 import com.codeit.blob.comment.repository.CommentJpaRepository;
 import com.codeit.blob.comment.repository.CommentLikeJpaRepository;
 import com.codeit.blob.comment.request.CreateCommentRequest;
+import com.codeit.blob.comment.response.CommentPageResponse;
 import com.codeit.blob.comment.response.CommentResponse;
 import com.codeit.blob.comment.response.DeleteCommentResponse;
 import com.codeit.blob.global.exceptions.CustomException;
@@ -91,19 +92,20 @@ public class CommentService {
     }
 
     @Transactional(readOnly = true)
-    public List<CommentResponse> getPostComments(
+    public CommentPageResponse getPostComments(
             CustomUsers userDetails,
             Long postId,
-            int page
+            int page,
+            int limit
     ){
         Users user = userDetails == null ? null : userDetails.getUsers();
         Post post = postJpaRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 
-        Pageable pageable = PageRequest.of(page - 1, 10);
-        List<Comment> comments = commentJpaRepository.findByPostOrderByCreatedDateAsc(post, pageable).getContent();
+        Pageable pageable = PageRequest.of(page, limit);
+        Page<Comment> comments = commentJpaRepository.findByPostOrderByCreatedDateAsc(post, pageable);
 
-        return comments.stream().map(c -> new CommentResponse(c, user)).toList();
+        return new CommentPageResponse(comments, user);
     }
 
     @Transactional

--- a/src/main/java/com/codeit/blob/global/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/blob/global/config/SecurityConfig.java
@@ -37,7 +37,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(request -> request
                 .requestMatchers(PathRequest.toH2Console()).permitAll()
                 .requestMatchers(PERMIT_URL).permitAll()
-                .requestMatchers(HttpMethod.GET, "/post/**", "/comment/post/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/post/**", "/comment/**").permitAll()
                 .anyRequest().authenticated());
 
         http

--- a/src/main/java/com/codeit/blob/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/codeit/blob/jwt/filter/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     };
 
     private static final String[] GET_EXCLUDE_PATH = {
-            "/post/", "/comment/post/"
+            "/post/", "/comment/"
     };
 
     private final JwtProvider provider;

--- a/src/main/java/com/codeit/blob/post/domain/Post.java
+++ b/src/main/java/com/codeit/blob/post/domain/Post.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -105,6 +106,11 @@ public class Post extends BaseTimeEntity {
 
     public void removeBookmark(Bookmark bookmark){
         bookmarks.remove(bookmark);
+    }
+
+    public LocalDateTime getExpiresAt(){
+        long plus = 30 * likes.size() * 10L;
+        return getCreatedDate().plusMinutes(plus);
     }
 
 }

--- a/src/main/java/com/codeit/blob/post/domain/Post.java
+++ b/src/main/java/com/codeit/blob/post/domain/Post.java
@@ -27,6 +27,7 @@ public class Post extends BaseTimeEntity {
 
     private String title;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/codeit/blob/post/domain/Subcategory.java
+++ b/src/main/java/com/codeit/blob/post/domain/Subcategory.java
@@ -3,11 +3,17 @@ package com.codeit.blob.post.domain;
 import java.util.Arrays;
 
 public enum Subcategory {
-    // todo add finalised list
+
     WEATHER("날씨"),
-    ATM("ATM"),
     RESTAURANT("음식점"),
-    ACCOMMODATION("숙소");
+    ACCOMMODATION("숙소"),
+    HOSPITAL("병원"),
+    TOILET("화장실"),
+    PHARMACY("약국"),
+    TRANSPORT("교통"),
+    MUSEUM("박물관"),
+    ATTRACTIONS("관광지"),
+    ATM("ATM");
 
     private String label;
 

--- a/src/main/java/com/codeit/blob/post/request/CreatePostRequest.java
+++ b/src/main/java/com/codeit/blob/post/request/CreatePostRequest.java
@@ -16,11 +16,11 @@ import lombok.NoArgsConstructor;
 public class CreatePostRequest {
 
     @NotEmpty(message = "게시글 제목은 필수값입니다.")
-    @Schema(description = "게시글 내용", example = "title")
+    @Schema(description = "게시글 제목", example = "title")
     private String title;
 
-    @Size(max = 10000)
-    @Schema(description = "게시글 내용", example = "content")
+    @Size(max = 2000)
+    @Schema(description = "게시글 내용, 최대 2000자", example = "content")
     private String content;
 
     @NotNull(message = "게시글 카테고리는 필수값입니다.")

--- a/src/main/java/com/codeit/blob/post/request/CreatePostRequest.java
+++ b/src/main/java/com/codeit/blob/post/request/CreatePostRequest.java
@@ -3,6 +3,7 @@ package com.codeit.blob.post.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,6 +19,7 @@ public class CreatePostRequest {
     @Schema(description = "게시글 내용", example = "title")
     private String title;
 
+    @Size(max = 10000)
     @Schema(description = "게시글 내용", example = "content")
     private String content;
 

--- a/src/main/java/com/codeit/blob/post/response/PostResponse.java
+++ b/src/main/java/com/codeit/blob/post/response/PostResponse.java
@@ -28,6 +28,7 @@ public class PostResponse {
     private final Long views;
     @Schema(example = "2024-04-24T12:59:24")
     private final String createdDate;
+    private final String expiresAt;
     private final List<String> imageUrl;
     private final boolean liked;
     private final boolean bookmarked;
@@ -49,6 +50,7 @@ public class PostResponse {
         this.distFromActual = post.getDistFromActual();
         this.views = post.getViews();
         this.createdDate = post.getCreatedDate().truncatedTo(ChronoUnit.SECONDS).toString();
+        this.expiresAt = post.getExpiresAt().truncatedTo(ChronoUnit.SECONDS).toString();
         this.imageUrl = post.getPostImages().stream().map(PostImage::getUrl).toList();
         this.liked = user != null && post.getLikes().stream().map(l -> l.getUser().getId()).toList().contains(user.getId());
         this.bookmarked = user != null && post.getBookmarks().stream().map(b -> b.getUser().getId()).toList().contains(user.getId());


### PR DESCRIPTION
- 무한스크롤용 코멘트 페이지 응답 구현
- 답글 엔드포인트 분리 -> 페이지 사용
- 내용 글자수 제한 추가
- 게시글 세부 카테고리 추가
- 게시글 expiresAt 계산 메서드, 응답에 추가