### PR TITLE
fix[User] : use userId in apis instead of oauthId or blobId

### DIFF
--- a/src/main/java/com/codeit/blob/comment/repository/CommentJpaRepository.java
+++ b/src/main/java/com/codeit/blob/comment/repository/CommentJpaRepository.java
@@ -16,6 +16,5 @@ public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 
     Page<Comment> findByParentIdOrderByCreatedDateAsc(Long parentId, Pageable pageable);
 
-    @Query("SELECT c FROM Comment c WHERE c.author.blobId = :blobId")
-    Page<Comment> findCommentByAuthorBlobId(@Param("blobId") String blobId, Pageable pageable);
+    Page<Comment> findByAuthorId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/codeit/blob/oauth/response/OauthResponse.java
+++ b/src/main/java/com/codeit/blob/oauth/response/OauthResponse.java
@@ -8,14 +8,15 @@ import lombok.Getter;
 @Getter
 @Schema(name = "Oauth 로그인 성공 응답 데이터")
 public class OauthResponse {
-    private final String oauthId;
+
+    private final Long userId;
     private final String accessToken;
     private final String refreshToken;
     private final UserAuthenticateState state;
 
     @Builder
-    public OauthResponse(String oauthId, String accessToken, String refreshToken, UserAuthenticateState state) {
-        this.oauthId = oauthId;
+    public OauthResponse(Long userId, String accessToken, String refreshToken, UserAuthenticateState state) {
+        this.userId = userId;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.state = state;

--- a/src/main/java/com/codeit/blob/oauth/service/GoogleService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/GoogleService.java
@@ -74,10 +74,10 @@ public class GoogleService implements OauthService {
                         .refreshToken(refreshToken)
                         .build()
         );
-        userRepository.save(users);
+        users = userRepository.save(users);
 
         return OauthResponse.builder()
-                .oauthId(userInfo.getId())
+                .userId(users.getId())
                 .state(users.getState())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/codeit/blob/oauth/service/KakaoService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/KakaoService.java
@@ -72,10 +72,10 @@ public class KakaoService implements OauthService {
                         .refreshToken(refreshToken)
                         .build()
         );
-        userRepository.save(users);
+        users = userRepository.save(users);
 
         return OauthResponse.builder()
-                .oauthId(userInfo.getId())
+                .userId(users.getId())
                 .state(users.getState())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/codeit/blob/oauth/service/NaverService.java
+++ b/src/main/java/com/codeit/blob/oauth/service/NaverService.java
@@ -74,10 +74,11 @@ public class NaverService implements OauthService {
                         .refreshToken(refreshToken)
                         .build()
         );
-        userRepository.save(users);
+
+        users = userRepository.save(users);
 
         return OauthResponse.builder()
-                .oauthId(userInfo.getId())
+                .userId(users.getId())
                 .state(users.getState())
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)

--- a/src/main/java/com/codeit/blob/post/repository/BookmarkJpaRepository.java
+++ b/src/main/java/com/codeit/blob/post/repository/BookmarkJpaRepository.java
@@ -18,7 +18,6 @@ public interface BookmarkJpaRepository extends JpaRepository<Bookmark, Long> {
 
     List<Bookmark> findByUserIdAndCityId(Long userId, Long cityId);
 
-    @Query("select b from Bookmark b join fetch b.post where b.user.blobId = :blobId")
-    Page<Bookmark> findByUserBlobId(@Param("blobId") String blobId, Pageable pageable);
+    Page<Bookmark> findByUserId(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/codeit/blob/post/repository/PostJpaRepository.java
+++ b/src/main/java/com/codeit/blob/post/repository/PostJpaRepository.java
@@ -1,17 +1,13 @@
 package com.codeit.blob.post.repository;
 
-import com.codeit.blob.post.domain.Bookmark;
 import com.codeit.blob.post.domain.Post;
-import com.codeit.blob.user.domain.Users;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostJpaRepository extends JpaRepository<Post, Long> {
-    @Query("SELECT p FROM Post p WHERE p.author.blobId = :blobId")
-    Page<Post> findPostsByAuthorBlobId(@Param("blobId") String blobId, Pageable pageable);
+
+    Page<Post> findByAuthorId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/codeit/blob/user/controller/UserController.java
+++ b/src/main/java/com/codeit/blob/user/controller/UserController.java
@@ -37,9 +37,10 @@ public class UserController {
     @SecurityRequirement(name = "Bearer Authentication")
     @Operation(summary = "유저 추가 인증 API", description = "blobId, nickName 을 입력 받아 인증합니다.")
     public ResponseEntity<UserResponse> validationUser(
+            @AuthenticationPrincipal CustomUsers userDetails,
             @Valid @RequestBody UserRequest userRequest
     ) {
-        return ResponseEntity.ok(userService.validationUser(userRequest));
+        return ResponseEntity.ok(userService.validationUser(userDetails, userRequest));
     }
 
     @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -59,47 +60,39 @@ public class UserController {
         return ResponseEntity.ok(userResponse);
     }
 
-    @GetMapping("/{blobId}/blob")
-    @Operation(summary = "회원 조회 API", description = "Blob Id 를 입력받아 회원을 조회합니다.")
+    @GetMapping("/{userId}")
+    @Operation(summary = "회원 조회 API", description = "User Id 를 입력받아 회원을 조회합니다.")
     public ResponseEntity<UserResponse> findUserByBlobId(
-            @PathVariable("blobId") String blobId
+            @PathVariable("userId") Long userId
     ) {
-        return ResponseEntity.ok(userService.findByBlobId(blobId));
+        return ResponseEntity.ok(userService.findByUserId(userId));
     }
 
-    @GetMapping("/{oauthId}/oauth")
-    @Operation(summary = "회원 조회 API", description = "Oauth Id 를 입력받아 회원을 조회합니다.")
-    public ResponseEntity<UserResponse> findUserByOauthId(
-            @PathVariable("oauthId") String oauthId
-    ) {
-        return ResponseEntity.ok(userService.findByOauthId(oauthId));
-    }
-
-    @GetMapping("/{blobId}/profile")
+    @GetMapping("/{userId}/post")
     @Operation(summary = "유저가 작성한 게시글 조회 API", description = "Page 처리를 통한 게시글 조회")
     public ResponseEntity<PostPageResponse> findPostPage(
-            @PathVariable("blobId") String blobId,
+            @PathVariable("userId") Long userId,
             @ParameterObject Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findUserPosts(blobId, pageable));
+        return ResponseEntity.ok(service.findUserPosts(userId, pageable));
     }
 
-    @GetMapping("/{blobId}/comment")
+    @GetMapping("/{userId}/comment")
     @Operation(summary = "유저가 작성한 댓글 조회 API", description = "Page 처리를 통한 유저가 작성한 댓글 조회")
     public ResponseEntity<CommentPageResponse> findComment(
-            @PathVariable("blobId") String blobId,
+            @PathVariable("userId") Long userId,
             @ParameterObject Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findUserComment(blobId, pageable));
+        return ResponseEntity.ok(service.findUserComment(userId, pageable));
     }
 
-    @GetMapping("/{blobId}/bookmark")
+    @GetMapping("/{userId}/bookmark")
     @Operation(summary = "유저의 북마크 조회 API", description = "Page 처리를 통한 북마크 조회")
     public ResponseEntity<PostPageResponse> findBookmark(
-            @PathVariable("blobId") String blobId,
+            @PathVariable("userId") Long userId,
             @ParameterObject Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findUserBookmark(blobId, pageable));
+        return ResponseEntity.ok(service.findUserBookmark(userId, pageable));
     }
 
     @PostMapping("/makeAdmin")

--- a/src/main/java/com/codeit/blob/user/request/UserRequest.java
+++ b/src/main/java/com/codeit/blob/user/request/UserRequest.java
@@ -2,14 +2,13 @@ package com.codeit.blob.user.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 @Schema(name = "유저 추가 인증 요청 데이터")
 public class UserRequest {
-    @NotEmpty(message = "oauthId 는 필수 데이터 입니다.")
-    @Schema(description = "Oauth 아이디", example = "14685162935")
-    private final String oauthId;
 
     @NotEmpty(message = "blobId 는 필수 데이터 입니다.")
     @Schema(description = "유저 서비스 아이디", example = "blobblob1234")
@@ -19,9 +18,4 @@ public class UserRequest {
     @Schema(description = "닉네임", example = "코드코드")
     private final String nickName;
 
-    public UserRequest(String oauthId, String blobId, String nickName) {
-        this.oauthId = oauthId;
-        this.blobId = blobId;
-        this.nickName = nickName;
-    }
 }

--- a/src/main/java/com/codeit/blob/user/response/UserProfileResponse.java
+++ b/src/main/java/com/codeit/blob/user/response/UserProfileResponse.java
@@ -8,14 +8,18 @@ import lombok.Getter;
 @Schema(name = "유저 프로필 정보 응답")
 public class UserProfileResponse {
 
+    private final Long userId;
     private final String blobId;
     private final String nickname;
     private final String profileUrl;
+    private final Integer likedCount;
 
     public UserProfileResponse(Users user){
+        this.userId = user.getId();
         this.blobId = user.getBlobId();
         this.nickname = user.getNickName();
         this.profileUrl = user.getProfileUrl();
+        this.likedCount = user.getLikeCount();
     }
 
 }

--- a/src/main/java/com/codeit/blob/user/response/UserResponse.java
+++ b/src/main/java/com/codeit/blob/user/response/UserResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 @Getter
 @Schema(name = "유저 조회 응답 데이터")
 public class UserResponse {
+
     private final Long userId;
     private final String email;
     private final String blobId;

--- a/src/main/java/com/codeit/blob/user/service/UserPageService.java
+++ b/src/main/java/com/codeit/blob/user/service/UserPageService.java
@@ -30,27 +30,27 @@ public class UserPageService {
     private final BookmarkJpaRepository bookmarkRepository;
     private final UserRepository userRepository;
 
-    public PostPageResponse findUserPosts(String blobId, Pageable pageable) {
-        Users users = userRepository.findByBlobId(blobId)
+    public PostPageResponse findUserPosts(Long userId, Pageable pageable) {
+        Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Page<Post> postPage = postRepository.findPostsByAuthorBlobId(blobId, pageable);
+        Page<Post> postPage = postRepository.findByAuthorId(userId, pageable);
         return PostPageResponse.postDetailPageResponse(postPage, users);
     }
 
-    public CommentPageResponse findUserComment(String blobId, Pageable pageable) {
-        Users users = userRepository.findByBlobId(blobId)
+    public CommentPageResponse findUserComment(Long userId, Pageable pageable) {
+        Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Page<Comment> byAuthor = commentRepository.findCommentByAuthorBlobId(blobId, pageable);
+        Page<Comment> byAuthor = commentRepository.findByAuthorId(userId, pageable);
         return CommentPageResponse.commentDetailedPageResponse(byAuthor, users);
     }
 
-    public PostPageResponse findUserBookmark(String blobId, Pageable pageable) {
-        Users users = userRepository.findByBlobId(blobId)
+    public PostPageResponse findUserBookmark(Long userId, Pageable pageable) {
+        Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Page<Bookmark> bookmarkPage = bookmarkRepository.findByUserBlobId(blobId, pageable);
+        Page<Bookmark> bookmarkPage = bookmarkRepository.findByUserId(userId, pageable);
         Page<Post> postPage = bookmarkPage.map(Bookmark::getPost);
         return PostPageResponse.postDetailPageResponse(postPage, users);
     }

--- a/src/main/java/com/codeit/blob/user/service/UserService.java
+++ b/src/main/java/com/codeit/blob/user/service/UserService.java
@@ -25,13 +25,12 @@ public class UserService {
     private final S3Service s3Service;
 
     @Transactional
-    public UserResponse validationUser(UserRequest userRequest) {
+    public UserResponse validationUser(CustomUsers userDetails, UserRequest userRequest) {
         if (existBlobId(userRequest.getBlobId())) {
             throw new CustomException(ErrorCode.DUPLICATE_BLOB_ID);
         }
 
-        Users users = userRepository.findByOauthId(userRequest.getOauthId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Users users = userDetails.getUsers();
 
         users.changeUser(
                 users.toBuilder()
@@ -71,15 +70,8 @@ public class UserService {
         return new UserResponse(users);
     }
 
-    public UserResponse findByOauthId(String oauthId) {
-        Users users = userRepository.findByOauthId(oauthId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        return new UserResponse(users);
-    }
-
-    public UserResponse findByBlobId(String blobId) {
-        Users users = userRepository.findByBlobId(blobId)
+    public UserResponse findByUserId(Long userId) {
+        Users users = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return new UserResponse(users);


### PR DESCRIPTION
프론트 요청 반영:
- user 관련 api 에서 모두 userId 사용
- GET user/{userId} url 수정 (불필요한 /blob) 제거
- 회원가입에서 oauthId 사용을 빼고 @AuthenticationPrincipal 사용